### PR TITLE
Fix throw counting on busts.

### DIFF
--- a/src/zero1.vue
+++ b/src/zero1.vue
@@ -118,6 +118,10 @@ export default {
           player.score += this.calculateValue(rec).score
         })
 
+        while (player.throws.length % 3 != 0) {
+          player.throws.push(null)
+        }
+
         this.record.push('bust')
         this.playerchange = true
         return


### PR DESCRIPTION
On busts on the first or second dart, currently, the number of entries in ``player.throws`` is not a multiple of 3 anymore, resulting in the next round for that player to end prematurely.

This PR fixes this issue by filling in misses at busts to restore the invariant that player.throws.length is always a multiple of 3 after any round.