### PR TITLE
Fix reset.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -100,7 +100,7 @@ export default {
     },
     reset() {
       this.game = 0
-      this.players = 0
+      this.players = []
       this.gamestarted = false
     },
     setPlayers(count) {


### PR DESCRIPTION
When moving back to the main menu, starting another game was broken, since the ``this.players`` was set to the number 0, but is elsewhere expected to be an array.